### PR TITLE
#54 bug: 가스 사용량 조회 bug

### DIFF
--- a/Server/carbonTracker/src/main/java/capstoneDesign/carbonTracker/apartment/service/AptEnergyService.java
+++ b/Server/carbonTracker/src/main/java/capstoneDesign/carbonTracker/apartment/service/AptEnergyService.java
@@ -119,7 +119,7 @@ public class AptEnergyService {
 
                 String bunji;
 
-                if (tokens[2].charAt(tokens[2].length() - 1) == '군') bunji = tokens[4];
+                if (tokens[1].charAt(tokens[1].length() - 1) == '군') bunji = tokens[4];
                 else bunji = tokens[3];
 
                 String sigunguCode = sigunguCodeMap.get(tokens[1]);


### PR DESCRIPTION
* 특정 단지의 가스 사용량 조회 시, 사용량이 모두 0으로 나오는 Bug
* 달성군과 같은 경우, 다른 구와 달리 번,지가 주소 중 다섯번째 위치에 존재했고, 인덱스를 수정함으로써 해결